### PR TITLE
Enabled asset_host for CDN url

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -55,7 +55,7 @@ Rails.application.configure do
   # config.cache_store = :mem_cache_store
 
   # Enable serving of images, stylesheets, and JavaScripts from an asset server.
-  # config.action_controller.asset_host = "http://assets.example.com"
+  config.action_controller.asset_host = "http://cdn.cambase.io"
 
   # Precompile additional assets.
   # application.js, application.css, and all non-JS/CSS in app/assets folder are already added.


### PR DESCRIPTION
Enabled config.action_controller.asset_host = "http://cdn.cambase.io" after setting up CDN at AWS CloudFront against S3 bucket